### PR TITLE
Release 0.0.1 (and add preversion and postversion npm hooks)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kibana-ui-framework",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Kibana UI Framework",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,16 @@
 {
   "name": "kibana-ui-framework",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "Kibana UI Framework",
   "main": "index.js",
   "scripts": {
     "start": "./node_modules/.bin/webpack-dev-server --hot --inline --content-base public/",
     "build": "./node_modules/.bin/webpack -p",
     "deploy": "npm run build; gh-pages -d public -r https://github.com/elastic/kibana-ui-framework",
-    "dist": "./node_modules/node-sass/bin/node-sass ./src/framework/framework.scss ./public/framework.css"
+    "dist": "./node_modules/node-sass/bin/node-sass ./src/framework/framework.scss ./public/framework.css",
+    "preversion": "npm run dist",
+    "postversion": "npm run deploy"
   },
   "dependencies": {
     "babel-core": "6.10.4",


### PR DESCRIPTION
Now when you run `npm version {patch/minor/major}`, the CSS will be compiled with the `dist` script and the build will be deployed with the `deploy` script.