### PR TITLE
Add support for dark theme.

### DIFF
--- a/src/framework/components/local_nav/_index.scss
+++ b/src/framework/components/local_nav/_index.scss
@@ -1,5 +1,42 @@
+// Normal colors
+$localNavTextColor: $textColor;
+$localNavBackgroundColor: #e4e4e4;
+$localNavButtonTextColor: #5a5a5a;
+$localNavButtonTextColor-isHover: #000000;
+$localNavButtonBackgroundColor: transparent;
+$localNavButtonBackgroundColor-isHover: rgba(#000000, 0.1);
+$localNavButtonBackgroundColor-isSelected: #f6f6f6;
+$localNavBreadcrumbDelimiterColor: #5a5a5a;
+$localSearchBackgroundColor: #ffffff;
+$localSearchBorderColor-isInvalid: #e74C3c;
+$localDropdownBackgroundColor: $localNavButtonBackgroundColor-isSelected;
+$localDropdownFormNoteTextColor: #737373;
+$localTabTextColor: $localNavButtonTextColor;
+$localTabTextColor-isHover: $localNavButtonTextColor-isHover;
+$localTabTextColor-isSelected: $localNavButtonTextColor-isHover;
 
+// Dark theme colors
+$localNavTextColor--darkTheme: $textColor--darkTheme;
+$localNavBackgroundColor--darkTheme: #333333;
+$localNavButtonTextColor--darkTheme: #dedede;
+$localNavButtonTextColor-isHover--darkTheme: #ffffff;
+$localNavButtonBackgroundColor-isHover--darkTheme: #000000;
+$localNavButtonBackgroundColor-isSelected--darkTheme: #525252;
+$localNavBreadcrumbDelimiterColor--darkTheme: #a5a5a5;
+$localSearchBackgroundColor--darkTheme: #4e4e4e;
+$localSearchBorderColor-isInvalid--darkTheme: #ff6758;
+$localDropdownBackgroundColor--darkTheme: $localNavButtonBackgroundColor-isSelected--darkTheme;
+$localDropdownFormNoteTextColor--darkTheme: #a2a2a2;
+$localDropdownWarningTextColor--darkTheme: $textColor--darkTheme;
+$localDropdownWarningBackgroundColor--darkTheme: #636363;
+$localTabTextColor--darkTheme: $localNavButtonTextColor--darkTheme;
+$localTabTextColor-isHover--darkTheme: $localNavButtonTextColor-isHover--darkTheme;
+$localTabTextColor-isSelected--darkTheme: $localNavButtonTextColor-isHover--darkTheme;
+
+// Spacing
 $localNavSideSpacing: 10px;
+
+// Font size
 $localNavFontSizeNormal: 14px;
 
 @import "local_breadcrumbs";

--- a/src/framework/components/local_nav/_local_breadcrumbs.scss
+++ b/src/framework/components/local_nav/_local_breadcrumbs.scss
@@ -18,16 +18,25 @@
         content: '/';
         user-select: none;
         margin-right: 4px;
-        color: #5a5a5a;
+        color: $localNavBreadcrumbDelimiterColor;
+
+        @include darkTheme {
+          color: $localNavBreadcrumbDelimiterColor--darkTheme;
+        }
       }
     }
 
     &:last-child {
       .localBreadcrumb__link {
         pointer-events: none;
-        color: #2d2d2d;
+        color: $localNavTextColor;
+
+        @include darkTheme {
+          color: $localNavTextColor--darkTheme;
+        }
       }
     }
+
   }
 
     .localBreadcrumb__link {
@@ -37,6 +46,10 @@
 
       &:hover {
         text-decoration: underline;
+      }
+
+      @include darkTheme {
+        color: $localNavButtonTextColor--darkTheme;
       }
     }
 

--- a/src/framework/components/local_nav/_local_dropdown.scss
+++ b/src/framework/components/local_nav/_local_dropdown.scss
@@ -1,8 +1,12 @@
 
 .localDropdown {
   padding: 10px $localNavSideSpacing 14px;
-  background-color: #f6f6f6;
+  background-color: $localDropdownBackgroundColor;
   line-height: 20px;
+
+  @include darkTheme {
+    background-color: $localDropdownBackgroundColor--darkTheme;
+  }
 }
 
 .localDropdownPanels {
@@ -24,7 +28,11 @@
 .localDropdownTitle {
   margin-bottom: 12px;
   font-size: 18px;
-  color: #000000;
+  color: $localNavTextColor;
+
+  @include darkTheme {
+    color: $localNavTextColor--darkTheme;
+  }
 }
 
 .localDropdownSection {
@@ -45,7 +53,11 @@
   .localDropdownHeader__label {
     font-size: 14px;
     font-weight: 700;
-    color: #000000;
+    color: $localNavTextColor;
+
+    @include darkTheme {
+      color: $localNavTextColor--darkTheme;
+    }
   }
 
   .localDropdownHeader__actions {
@@ -53,9 +65,10 @@
   }
 
   .localDropdownHeader__action {
-    color: #328CAA;
+    color: $linkColor;
     font-size: 12px;
     text-decoration: none;
+    cursor: pointer;
 
     & + & {
       margin-left: 10px;
@@ -63,7 +76,16 @@
 
     &:hover,
     &:active {
-      color: #105A73;
+      color: $linkColor-isHover;
+    }
+
+    @include darkTheme {
+      color: $linkColor--darkTheme;
+
+      &:hover,
+      &:active {
+        color: $linkColor-isHover--darkTheme;
+      }
     }
   }
 
@@ -73,26 +95,46 @@
   margin-bottom: 12px;
   padding: 5px 15px;
   font-size: 14px;
-  color: #2d2d2d;
-  border: 2px solid #ffffff;
+  color: $inputTextColor;
+  background-color: $inputBackgroundColor;
+  border: 2px solid $inputBorderColor;
   border-radius: 4px;
+
+  @include darkTheme {
+    color: $inputTextColor--darkTheme;
+    background-color: $inputBackgroundColor--darkTheme;
+    border-color: $inputBorderColor--darkTheme;
+  }
 }
 
 .localDropdownFormNote {
   font-size: 14px;
-  color: #5A5A5A;
+  color: $localDropdownFormNoteTextColor;
+
+  @include darkTheme {
+    color: $localDropdownFormNoteTextColor--darkTheme;
+  }
 }
 
 .localDropdownWarning {
   margin-bottom: 16px;
   padding: 6px 10px;
   font-size: 14px;
-  color: #2D2D2D;
-  background-color: #e4e4e4;
+  color: $textColor;
+  background-color: $localNavBackgroundColor;
+
+  @include darkTheme {
+    color: $localDropdownWarningTextColor--darkTheme;
+    background-color: $localDropdownWarningBackgroundColor--darkTheme;
+  }
 }
 
 .localDropdownHelpText {
   margin-bottom: 16px;
   font-size: 14px;
   color: #2D2D2D;
+
+  @include darkTheme {
+    color: #9e9e9e;
+  }
 }

--- a/src/framework/components/local_nav/_local_menu.scss
+++ b/src/framework/components/local_nav/_local_menu.scss
@@ -11,24 +11,39 @@
     height: 100%;
     padding: 0 $localNavSideSpacing;
     font-size: $localNavFontSizeNormal;
-    background-color: transparent;
-    color: #5a5a5a;
+    background-color: $localNavButtonBackgroundColor;
+    color: $localNavButtonTextColor;
     border: 0;
     cursor: pointer;
 
     &:hover {
-      background-color: rgba(#000000, 0.1);
-      color: #000000;
+      background-color: $localNavButtonBackgroundColor-isHover;
+      color: $localNavButtonTextColor-isHover;
     }
 
     &.localMenuItem-isSelected {
-      background-color: #f6f6f6;
+      background-color: $localNavButtonBackgroundColor-isSelected;
+      cursor: default;
+      pointer-events: none;
     }
 
     &.localMenuItem-isDisabled {
       opacity: 0.5;
       cursor: default;
       pointer-events: none;
+    }
+
+    @include darkTheme {
+      color: $localNavButtonTextColor--darkTheme;
+
+      &:hover {
+        background-color: $localNavButtonBackgroundColor-isHover--darkTheme;
+        color: $localNavButtonTextColor-isHover--darkTheme;
+      }
+
+      &.localMenuItem-isSelected {
+        background-color: $localNavButtonBackgroundColor-isSelected--darkTheme;
+      }
     }
   }
 

--- a/src/framework/components/local_nav/_local_nav.scss
+++ b/src/framework/components/local_nav/_local_nav.scss
@@ -8,7 +8,13 @@
   flex-direction: column;
   justify-content: space-between;
   min-height: 70px; /* 1 */
-  background-color: #e4e4e4;
+  color: $localNavTextColor;
+  background-color: $localNavBackgroundColor;
+
+  @include darkTheme {
+    color: $localNavTextColor--darkTheme;
+    background-color: $localNavBackgroundColor--darkTheme;
+  }
 }
 
 .localNavRow {

--- a/src/framework/components/local_nav/_local_search.scss
+++ b/src/framework/components/local_nav/_local_search.scss
@@ -11,15 +11,26 @@ $localSearchHeight: 30px;
   flex: 1 1 100%;
   padding: 5px 15px;
   font-size: $localNavFontSizeNormal;
-  color: #2d2d2d;
-  border: 2px solid #ffffff;
+  color: $localNavTextColor;
+  background-color: $localSearchBackgroundColor;
+  border: 2px solid $localSearchBackgroundColor;
   border-bottom-left-radius: 4px;
   border-top-left-radius: 4px;
   border-bottom-right-radius: 0;
   border-top-right-radius: 0;
 
   &.localSearchInput-isInvalid {
-    border-color: #e74C3c;
+    border-color: $localSearchBorderColor-isInvalid;
+  }
+
+  @include darkTheme {
+    color: $localNavTextColor--darkTheme;
+    background-color: $localSearchBackgroundColor--darkTheme;
+    border-color: $localSearchBackgroundColor--darkTheme;
+
+    &.localSearchInput-isInvalid {
+      border-color: $localSearchBorderColor-isInvalid--darkTheme;
+    }
   }
 }
 
@@ -27,11 +38,16 @@ $localSearchHeight: 30px;
   width: 43px;
   height: $localSearchHeight;
   font-size: $localNavFontSizeNormal;
-  background-color: #9c9c9c;
-  color: #ffffff;
+  color: $buttonTextColor;
+  background-color: $buttonBackgroundColor;
   border: 0;
   border-bottom-left-radius: 0;
   border-top-left-radius: 0;
   border-bottom-right-radius: 4px;
   border-top-right-radius: 4px;
+
+  @include darkTheme {
+    color: $buttonTextColor--darkTheme;
+    background-color: $buttonBackgroundColor--darkTheme;
+  }
 }

--- a/src/framework/components/local_nav/_local_tabs.scss
+++ b/src/framework/components/local_nav/_local_tabs.scss
@@ -1,7 +1,9 @@
-
+/**
+ * 1. We want the bottom border on selected tabs to be flush with the bottom of the container.
+ */
 .localTabs {
   display: flex;
-  align-items: center;
+  align-items: flex-end; // 1
   height: 100%;
 }
 
@@ -12,21 +14,36 @@
     padding: 5px 0 6px 0;
     font-size: 18px;
     line-height: 22px; /* 1 */
-    color: #5a5a5a;
+    color: $localTabTextColor;
     border-bottom: 2px solid transparent;
     text-decoration: none;
+    cursor: pointer;
 
     &:hover,
     &:active {
-      color: #2d2d2d;
+      color: $localTabTextColor-isHover;
+
+      @include darkTheme {
+        color: $localTabTextColor-isHover--darkTheme;
+      }
     }
 
     &.localTab-isSelected {
-      color: #2d2d2d;
-      border-bottom-color: #2d2d2d;
+      color: $localTabTextColor-isSelected;
+      border-bottom-color: $localTabTextColor-isSelected;
+      cursor: default;
+
+      @include darkTheme {
+        color: $localTabTextColor-isSelected--darkTheme;
+        border-bottom-color: $localTabTextColor-isSelected--darkTheme;
+      }
     }
 
     & + & {
       margin-left: 15px;
+    }
+
+    @include darkTheme {
+      color: $localTabTextColor--darkTheme;
     }
   }

--- a/src/framework/framework.scss
+++ b/src/framework/framework.scss
@@ -1,1 +1,27 @@
+// Normal colors
+$textColor: #2d2d2d;
+$buttonTextColor: #ffffff;
+$buttonBackgroundColor: #9c9c9c;
+$linkColor: #328CAA;
+$linkColor-isHover: #105A73;
+$inputTextColor: $textColor;
+$inputBackgroundColor: #ffffff;
+$inputBorderColor: $inputBackgroundColor;
+
+// Dark theme colors
+$textColor--darkTheme: #cecece;
+$buttonTextColor--darkTheme: #ffffff;
+$buttonBackgroundColor--darkTheme: #777777;
+$linkColor--darkTheme: #b7e2ea;
+$linkColor-isHover--darkTheme: #def2f6;
+$inputTextColor--darkTheme: $textColor--darkTheme;
+$inputBackgroundColor--darkTheme: #444444;
+$inputBorderColor--darkTheme: $inputBackgroundColor--darkTheme;
+
+@mixin darkTheme() {
+  .theme-dark & {
+    @content;
+  }
+}
+
 @import "components/local_nav/index";

--- a/src/guide/components/guide_page_section/_guide_page_section.scss
+++ b/src/guide/components/guide_page_section/_guide_page_section.scss
@@ -45,6 +45,12 @@
     line-height: 21px;
   }
 
+  .guidePageSection__example {
+    & + & {
+      margin-top: 20px;
+    }
+  }
+
   .guidePageSection__example--standalone {
     margin-top: 10px;
   }

--- a/src/guide/components/guide_page_section/guide_page_section.jsx
+++ b/src/guide/components/guide_page_section/guide_page_section.jsx
@@ -46,6 +46,7 @@ export default class GuidePageSection extends Component {
     }
 
     trimChildren(this.refs.html);
+    trimChildren(this.refs.htmlDarkTheme);
   }
 
   componentWillUnmount() {
@@ -68,7 +69,7 @@ export default class GuidePageSection extends Component {
       );
     }
 
-    const exampleClasses = classNames({
+    const exampleClasses = classNames('guidePageSection__example', {
       'guidePageSection__example--standalone': !this.props.children,
     });
 
@@ -92,6 +93,12 @@ export default class GuidePageSection extends Component {
         <div
           ref="html"
           className={exampleClasses}
+          dangerouslySetInnerHTML={{ __html: this.props.html }}
+        />
+
+        <div
+          ref="htmlDarkTheme"
+          className={`${exampleClasses} theme-dark`}
           dangerouslySetInnerHTML={{ __html: this.props.html }}
         />
       </div>


### PR DESCRIPTION
Addresses https://github.com/elastic/kibana/issues/8925
Gets us closer to https://github.com/elastic/kibana/issues/6786

Changes:
- Show dark theme examples for all components.
- Add styles for localNav dark theme.

![image](https://cloud.githubusercontent.com/assets/1238659/19977641/767068ca-a1b1-11e6-9b0b-96c015460925.png)

![image](https://cloud.githubusercontent.com/assets/1238659/19977647/7865d4da-a1b1-11e6-87be-47f0bb7edadd.png)

![image](https://cloud.githubusercontent.com/assets/1238659/19977649/7a2fda18-a1b1-11e6-9641-ea11a1897bff.png)
