### PR TITLE
Remove pointer-events: none from .localMenuItem-isSelected.

### DIFF
--- a/src/framework/components/local_nav/_local_menu.scss
+++ b/src/framework/components/local_nav/_local_menu.scss
@@ -23,8 +23,6 @@
 
     &.localMenuItem-isSelected {
       background-color: $localNavButtonBackgroundColor-isSelected;
-      cursor: default;
-      pointer-events: none;
     }
 
     &.localMenuItem-isDisabled {


### PR DESCRIPTION
We need to be able to click a selected menu item to close it.