### PR TITLE
Remove pointer-events: none from localBreadcrumbs and localMenuItem.

### DIFF
--- a/src/framework/components/local_nav/_local_breadcrumbs.scss
+++ b/src/framework/components/local_nav/_local_breadcrumbs.scss
@@ -28,8 +28,12 @@
 
     &:last-child {
       .localBreadcrumb__link {
-        pointer-events: none;
         color: $localNavTextColor;
+        cursor: default;
+
+        &:hover {
+          text-decoration: none;
+        }
 
         @include darkTheme {
           color: $localNavTextColor--darkTheme;

--- a/src/framework/components/local_nav/_local_menu.scss
+++ b/src/framework/components/local_nav/_local_menu.scss
@@ -28,7 +28,11 @@
     &.localMenuItem-isDisabled {
       opacity: 0.5;
       cursor: default;
-      pointer-events: none;
+
+      &:hover {
+        background-color: $localNavButtonBackgroundColor;
+        color: $localNavButtonTextColor;
+      }
     }
 
     @include darkTheme {
@@ -41,6 +45,13 @@
 
       &.localMenuItem-isSelected {
         background-color: $localNavButtonBackgroundColor-isSelected--darkTheme;
+      }
+
+      &.localMenuItem-isDisabled {
+        &:hover {
+          background-color: transparent;
+          color: $localNavButtonTextColor--darkTheme;
+        }
       }
     }
   }


### PR DESCRIPTION
This will allow tooltips to be used on these elements.